### PR TITLE
Doubt Earnings streamlining, some fixes for epistemic., minor changes…

### DIFF
--- a/src/actions/fetchRestakeForPoints.ts
+++ b/src/actions/fetchRestakeForPoints.ts
@@ -17,7 +17,7 @@ export const fetchRestakeForPoints = async (pointId: number, negationId: number)
     .select({
       totalRestakeAmount: sql<number>`
         SUM(${effectiveRestakesView.effectiveAmount})
-        FILTER (WHERE ${effectiveRestakesView.isActive} = true)
+        FILTER (WHERE ${effectiveRestakesView.slashedAmount} < ${effectiveRestakesView.amount})
       `.as('total_restake_amount')
     })
     .from(effectiveRestakesView)

--- a/src/actions/fetchRestakerReputation.ts
+++ b/src/actions/fetchRestakerReputation.ts
@@ -2,19 +2,21 @@
 
 import { db } from "@/services/db";
 import { and, eq, sql } from "drizzle-orm";
-import { restakesTable, slashesTable, doubtsTable } from "@/db/schema";
+import { restakesTable, slashesTable, doubtsTable, usersTable } from "@/db/schema";
 import { sqids } from "@/services/sqids";
 
 export type RestakerReputation = {
-  userId: string;
+  username: string | null;
+  hashedUserId: string;
   amount: number;
   reputation: number;
 };
 
 export const fetchRestakerReputation = async (pointId: number, negationId: number) => {
-  // Get all active restakers for this point-negation pair
+    // Get all active restakers for this point-negation pair
   const restakers = await db
     .select({
+      username: usersTable.username,
       userId: sql<string>`r.user_id`.as('user_id'),
       amount: sql<number>`SUM(r.amount)`.as('amount'),
       reputation: sql<number>`
@@ -84,32 +86,31 @@ export const fetchRestakerReputation = async (pointId: number, negationId: numbe
       `.as('reputation')
     })
     .from(sql`${restakesTable} r`)
+    .leftJoin(usersTable, eq(usersTable.id, sql`r.user_id`))
     .where(
       and(
         eq(sql`r.point_id`, pointId),
         eq(sql`r.negation_id`, negationId)
       )
     )
-    .groupBy(sql`r.user_id`);
+    .groupBy(sql`r.user_id`, usersTable.username);
 
-  // Calculate aggregate reputation
-  const totalAmount = restakers.reduce((sum, r) => sum + r.amount, 0);
+  const restakersWithHashedIds = restakers.map(r => ({
+    username: r.username,
+    hashedUserId: sqids.encode([r.userId.split('').reduce((sum, char) => sum + char.charCodeAt(0), 0)]),
+    amount: r.amount,
+    reputation: r.reputation
+  }));
+
+  const totalAmount = restakersWithHashedIds.reduce((sum, r) => sum + r.amount, 0);
   const aggregateReputation = totalAmount > 0 
     ? Math.round(
-        restakers.reduce((sum, r) => sum + (r.reputation * r.amount), 0) / totalAmount
+        restakersWithHashedIds.reduce((sum, r) => sum + (r.reputation * r.amount), 0) / totalAmount
       )
     : 50; // Default to 50% if no restakers, although this should never happen
 
-  // Hash user IDs - should work with any string
-  const hashedRestakers = restakers.map(r => ({
-    ...r,
-    userId: sqids.encode([
-      r.userId.split('').reduce((sum, char) => sum + char.charCodeAt(0), 0)
-    ])
-  }));
-
   return {
-    restakers: hashedRestakers,
+    restakers: restakersWithHashedIds,
     aggregateReputation
   };
 }; 

--- a/src/components/ReputationAnalysisDialog.tsx
+++ b/src/components/ReputationAnalysisDialog.tsx
@@ -2,12 +2,11 @@ import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { InfoIcon } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import type { RestakerReputation } from "@/actions/fetchRestakerReputation";
+import { DialogProps } from "@radix-ui/react-dialog";
+import type { RestakerReputationResponse } from "@/queries/useRestakerReputation";
 
-interface ReputationAnalysisDialogProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  restakers: RestakerReputation[];
+interface ReputationAnalysisDialogProps extends DialogProps {
+  restakers: RestakerReputationResponse['restakers'];
   aggregateReputation: number;
 }
 
@@ -48,24 +47,12 @@ export const ReputationAnalysisDialog = ({
             <h3 className="font-medium">Current Restakers</h3>
             <div className="space-y-3">
               {restakers.map((restaker) => (
-                <div 
-                  key={restaker.userId} 
-                  className="flex items-center justify-between p-3 rounded-lg border hover:bg-muted/50 transition-colors"
-                >
-                  <div className="space-y-1">
-                    <p className="font-medium">{restaker.userId}</p>
-                    <p className="text-sm text-muted-foreground">
-                      {restaker.amount} cred staked
-                    </p>
+                <div key={restaker.hashedUserId} className="flex justify-between items-center">
+                  <div className="flex items-center gap-2">
+                    <span>{restaker.username}</span>
+                    <span className="text-xs text-muted-foreground">({restaker.hashedUserId})</span>
                   </div>
-                  <div className="flex flex-col items-end gap-1">
-                    <span className="text-lg">
-                      {restaker.reputation}%
-                    </span>
-                    <span className="text-xs text-muted-foreground">
-                      reputation
-                    </span>
-                  </div>
+                  <span>{restaker.reputation}%</span>
                 </div>
               ))}
             </div>

--- a/src/components/RestakeDialog.tsx
+++ b/src/components/RestakeDialog.tsx
@@ -184,16 +184,19 @@ export const RestakeDialog: FC<RestakeDialogProps> = ({
 
   // Check if user can place a doubt
   const canDoubt = useMemo(() => {
+
     if (!openedFromSlashedIcon) return true; // Not in doubt mode
     if (isLoadingUserId) return false; // Still loading user
     if (!userId) return false; // No user logged in
     
-    // Check original amount instead of effective amount
-    const totalRestakeAmount = existingRestake?.amount ?? 0;
-    if (totalRestakeAmount === 0) return false; // No restakes to doubt
+    // Check total restake amount instead of user's restake amount
+    const totalRestakeAmount = existingRestake?.totalRestakeAmount ?? 0;
+    if (totalRestakeAmount === 0) {
+      return false;
+    }
     
     return true;
-  }, [openedFromSlashedIcon, existingRestake?.amount, userId, isLoadingUserId]);
+  }, [openedFromSlashedIcon, existingRestake?.totalRestakeAmount, userId, isLoadingUserId]);
 
   const favorReduced = stakedCred;
 
@@ -257,7 +260,7 @@ export const RestakeDialog: FC<RestakeDialogProps> = ({
 
     const factors = {
       stake: originalPoint.stakedAmount || 0,
-      restake: existingRestake?.amount ?? 0,
+      restake: existingRestake?.totalRestakeAmount ?? 0,
       cred: user?.cred ?? 0
     };
 
@@ -268,7 +271,7 @@ export const RestakeDialog: FC<RestakeDialogProps> = ({
     if (minValue === factors.cred) return "your available cred";
     
     return null;
-  }, [openedFromSlashedIcon, canDoubt, originalPoint.stakedAmount, existingRestake?.amount, user?.cred]);
+  }, [openedFromSlashedIcon, canDoubt, originalPoint.stakedAmount, existingRestake?.totalRestakeAmount, user?.cred]);
 
   // Loading state handler
   if (isLoadingUser) {
@@ -286,7 +289,7 @@ export const RestakeDialog: FC<RestakeDialogProps> = ({
     ? canDoubt 
       ? Math.min(
           originalPoint.stakedAmount || 0,        // Can't doubt more than total stake on point
-          existingRestake?.amount ?? 0,           // Use amount instead of totalRestakeAmount
+          existingRestake?.totalRestakeAmount ?? 0,  // Can't doubt more than total restake amount
           user?.cred ?? 0                         // Can't doubt more than user's available cred
         )
       : 0

--- a/src/hooks/usePrefetchRestakeData.ts
+++ b/src/hooks/usePrefetchRestakeData.ts
@@ -32,7 +32,7 @@ export const usePrefetchRestakeData = () => {
 
       // Restaker reputation
       queryClient.prefetchQuery({
-        queryKey: restakerReputationQueryKey({ pointId, negationId, userId: user?.id }),
+        queryKey: restakerReputationQueryKey(pointId, negationId, user?.id),
         queryFn: () => fetchRestakerReputation(pointId, negationId),
         staleTime
       }),

--- a/src/mutations/useCollectEarnings.ts
+++ b/src/mutations/useCollectEarnings.ts
@@ -1,0 +1,32 @@
+import { collectEarnings } from "@/actions/collectEarnings";
+import { useAuthenticatedMutation } from "@/mutations/useAuthenticatedMutation";
+import { userQueryKey } from "@/queries/useUser";
+import { usePrivy } from "@privy-io/react-auth";
+import { useQueryClient } from "@tanstack/react-query";
+import { useInvalidateRelatedPoints } from "@/queries/usePointData";
+
+export const useCollectEarnings = () => {
+  const queryClient = useQueryClient();
+  const { user } = usePrivy();
+  const invalidateRelatedPoints = useInvalidateRelatedPoints();
+
+  return useAuthenticatedMutation({
+    mutationFn: collectEarnings,
+    onSuccess: (result) => {
+      // Update user's cred balance
+      queryClient.invalidateQueries({
+        queryKey: userQueryKey(user?.id),
+      });
+
+      // Invalidate earnings preview
+      queryClient.invalidateQueries({
+        queryKey: ['earnings-preview']
+      });
+
+      // Invalidate each affected point and its relationships
+      result.affectedPoints.forEach(pointId => {
+        invalidateRelatedPoints(pointId);
+      });
+    },
+  });
+}; 

--- a/src/queries/useEarningsPreview.ts
+++ b/src/queries/useEarningsPreview.ts
@@ -1,0 +1,19 @@
+import { previewEarnings } from "@/actions/collectEarnings";
+import { usePrivy } from "@privy-io/react-auth";
+import { useQuery } from "@tanstack/react-query";
+
+interface UseEarningsPreviewOptions {
+  enabled?: boolean;
+}
+
+export const useEarningsPreview = ({ enabled = true }: UseEarningsPreviewOptions = {}) => {
+  const { user, ready, authenticated } = usePrivy();
+
+  return useQuery({
+    queryKey: ['earnings-preview', user?.id],
+    queryFn: previewEarnings,
+    enabled: enabled && ready && authenticated && !!user,
+    refetchInterval: (enabled && authenticated) ? 60 * 1000 : false,
+    retry: false  // Don't retry on auth errors
+  });
+}; 

--- a/src/queries/useRestakerReputation.ts
+++ b/src/queries/useRestakerReputation.ts
@@ -3,29 +3,18 @@ import { fetchRestakerReputation, RestakerReputation } from "@/actions/fetchRest
 import { usePrivy } from "@privy-io/react-auth";
 
 export type RestakerReputationResponse = {
-  restakers: Array<RestakerReputation>;
+  restakers: RestakerReputation[];
   aggregateReputation: number;
 };
 
-export const restakerReputationQueryKey = ({
-  pointId,
-  negationId,
-  userId,
-}: {
-  pointId: number;
-  negationId: number;
-  userId?: string;
-}) => ["restaker-reputation", pointId, negationId, userId];
+export const restakerReputationQueryKey = (pointId: number, negationId: number, userId?: string) => 
+  ["restaker-reputation", pointId, negationId, userId] as const;
 
 export const useRestakerReputation = (pointId: number, negationId: number) => {
   const { user: privyUser } = usePrivy();
 
   return useQuery<RestakerReputationResponse>({
-    queryKey: restakerReputationQueryKey({ 
-      pointId, 
-      negationId, 
-      userId: privyUser?.id 
-    }),
+    queryKey: restakerReputationQueryKey(pointId, negationId, privyUser?.id),
     queryFn: () => fetchRestakerReputation(pointId, negationId),
     enabled: !!pointId && !!negationId
   });


### PR DESCRIPTION
… to restaker rep

- Updated `collectEarnings` to return a structured result including `totalEarnings` and `affectedPoints`.
- Introduced `useCollectEarnings` mutation for handling earnings collection with proper query invalidation.
- Added `useEarningsPreview` hook for fetching earnings preview data based on user authentication state.
- Modified `fetchRestakerReputation` to include usernames and hashed user IDs for better user identification.
- Improved `EarningsDialog` and `PointCard` components for enhanced user experience and accurate display of earnings and restake information.
- Adjusted logic in `RestakeDialog` to utilize total restake amounts correctly.
- Cleaned up and optimized SQL queries in various actions for better performance and accuracy.
- Refactored both PointCard and Restake Dialogue to be more consistent with showing stuff