### PR TITLE
Refactor copy functionality in rationale components to support option…

### DIFF
--- a/src/app/s/[space]/rationale/[rationaleId]/page.tsx
+++ b/src/app/s/[space]/rationale/[rationaleId]/page.tsx
@@ -114,20 +114,23 @@ function ViewpointPageContent({ viewpointId, spaceSlug }: { viewpointId: string;
             initialPointData: node.data.initialPointData,
         }));
 
-    const { isCopying, isPageCopyConfirmOpen, setIsPageCopyConfirmOpen, handleCopy } = useCopyConfirm(async () => {
-        let currentGraph;
-        if (reactFlow) {
-            currentGraph = { nodes: reactFlow.getNodes(), edges: reactFlow.getEdges() };
-        } else {
-            currentGraph = localGraph!;
+    const { isCopying, isPageCopyConfirmOpen, setIsPageCopyConfirmOpen, handleCopy } = useCopyConfirm(
+        async (publishCopy: boolean = true) => {
+            let currentGraph;
+            if (reactFlow) {
+                currentGraph = { nodes: reactFlow.getNodes(), edges: reactFlow.getEdges() };
+            } else {
+                currentGraph = localGraph!;
+            }
+            await copyViewpointAndNavigate(
+                currentGraph,
+                editableTitle,
+                editableDescription,
+                viewpoint!.id,
+                publishCopy
+            );
         }
-        await copyViewpointAndNavigate(
-            currentGraph,
-            editableTitle,
-            editableDescription,
-            viewpoint!.id
-        );
-    });
+    );
 
     const spaceId = space?.data?.id!;
     const { data: topicsData } = useTopics(spaceId);

--- a/src/app/s/[space]/rationale/new/page.tsx
+++ b/src/app/s/[space]/rationale/new/page.tsx
@@ -171,6 +171,21 @@ function ViewpointContent({ setInitialTab }: { setInitialTab: (update: "points" 
     return id;
   };
 
+  const searchParams = useSearchParams();
+  const autoPublish = searchParams.get('autoPublish') === 'true';
+  const [autoPublishInvoked, setAutoPublishInvoked] = useState(false);
+  useEffect(() => {
+    if (
+      isCopiedFromSessionStorage &&
+      autoPublish &&
+      !autoPublishInvoked &&
+      canPublish
+    ) {
+      setAutoPublishInvoked(true);
+      handlePublish();
+    }
+  }, [isCopiedFromSessionStorage, autoPublish, autoPublishInvoked, canPublish, handlePublish]);
+
   const clearGraphAndState = useCallback(() => {
     startTransition(() => {
       // Set all atoms back to their defaults

--- a/src/components/rationale/ExistingRationaleHeader.tsx
+++ b/src/components/rationale/ExistingRationaleHeader.tsx
@@ -10,6 +10,8 @@ import { ViewpointIcon } from "@/components/icons/AppIcons";
 import { useAtom } from "jotai";
 import { showEndorsementsAtom } from "@/atoms/showEndorsementsAtom";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import { useState } from "react";
+import { Switch } from "@/components/ui/switch";
 
 export interface ExistingRationaleHeaderProps {
     isSharing: boolean;
@@ -19,7 +21,7 @@ export interface ExistingRationaleHeaderProps {
     handleCopyUrl: () => void;
     isPageCopyConfirmOpen: boolean;
     setIsPageCopyConfirmOpen: (open: boolean) => void;
-    handleCopy: () => void;
+    handleCopy: (publishOnCopy: boolean) => void;
     handleBackClick: () => void;
     canvasEnabled: boolean;
     toggleCanvas: () => void;
@@ -38,6 +40,7 @@ export default function ExistingRationaleHeader({
     canvasEnabled,
     toggleCanvas,
 }: ExistingRationaleHeaderProps) {
+    const [publishOnCopy, setPublishOnCopy] = useState(true);
     const [showEndorsements, setShowEndorsements] = useAtom(showEndorsementsAtom);
     return (
         <>
@@ -176,9 +179,13 @@ export default function ExistingRationaleHeader({
                             Are you sure you want to make a copy of this rationale?
                         </AlertDialogDescription>
                     </AlertDialogHeader>
+                    <div className="flex items-center space-x-2 px-6 py-4">
+                        <Switch checked={publishOnCopy} onCheckedChange={setPublishOnCopy} />
+                        <span className="text-sm">Publish after copy</span>
+                    </div>
                     <AlertDialogFooter>
                         <AlertDialogCancel>Cancel</AlertDialogCancel>
-                        <AlertDialogAction onClick={() => { setIsPageCopyConfirmOpen(false); handleCopy(); }}>
+                        <AlertDialogAction onClick={() => { setIsPageCopyConfirmOpen(false); handleCopy(publishOnCopy); }}>
                             Yes, make a copy
                         </AlertDialogAction>
                     </AlertDialogFooter>

--- a/src/hooks/viewpoints/useCopyConfirm.ts
+++ b/src/hooks/viewpoints/useCopyConfirm.ts
@@ -6,26 +6,29 @@ export interface UseCopyConfirm {
   isCopying: boolean;
   isPageCopyConfirmOpen: boolean;
   setIsPageCopyConfirmOpen: (open: boolean) => void;
-  handleCopy: () => Promise<void>;
+  handleCopy: (publishCopy?: boolean) => Promise<void>;
 }
 
 /**
  * Hook to manage page-copy confirmation dialog and perform copy action.
  */
 export function useCopyConfirm(
-  copyHandler: () => Promise<void>
+  copyHandler: (publishCopy?: boolean) => Promise<void>
 ): UseCopyConfirm {
   const [isCopying, setIsCopying] = useState(false);
   const [isPageCopyConfirmOpen, setIsPageCopyConfirmOpen] = useState(false);
 
-  const handleCopy = useCallback(async () => {
-    setIsCopying(true);
-    try {
-      await copyHandler();
-    } finally {
-      setIsCopying(false);
-    }
-  }, [copyHandler]);
+  const handleCopy = useCallback(
+    async (publishCopy: boolean = true) => {
+      setIsCopying(true);
+      try {
+        await copyHandler(publishCopy);
+      } finally {
+        setIsCopying(false);
+      }
+    },
+    [copyHandler]
+  );
 
   return {
     isCopying,

--- a/src/hooks/viewpoints/usePublishRationale.ts
+++ b/src/hooks/viewpoints/usePublishRationale.ts
@@ -11,6 +11,7 @@ import {
   viewpointReasoningAtom,
   viewpointTopicAtom,
   collapsedPointIdsAtom,
+  copiedFromIdAtom,
 } from "@/atoms/viewpointAtoms";
 import { useSpace } from "@/queries/space/useSpace";
 import { useTopics } from "@/queries/topics/useTopics";
@@ -26,6 +27,7 @@ export default function usePublishRationale() {
   const [description, setReasoning] = useAtom(viewpointReasoningAtom);
   const [topic, setTopic] = useAtom(viewpointTopicAtom);
   const [, setCollapsedPointIds] = useAtom(collapsedPointIdsAtom);
+  const [copiedFromId, setCopiedFromId] = useAtom(copiedFromIdAtom);
 
   const { mutateAsync, isPending } = usePublishViewpoint();
   const { push } = useRouter();
@@ -45,7 +47,6 @@ export default function usePublishRationale() {
         const found = topicsData.find((t) => t.name === topic);
         if (found) topicId = found.id;
       }
-      const copiedFromId = undefined;
       const id = await mutateAsync({
         title: statement,
         description,
@@ -59,6 +60,7 @@ export default function usePublishRationale() {
       setTopic("");
       setGraph(initialViewpointGraph);
       setCollapsedPointIds(new Set());
+      setCopiedFromId(undefined);
       if (reactFlow) {
         reactFlow.setNodes(initialViewpointGraph.nodes);
         reactFlow.setEdges(initialViewpointGraph.edges);
@@ -85,6 +87,8 @@ export default function usePublishRationale() {
     statement,
     topic,
     topicsData,
+    copiedFromId,
+    setCopiedFromId,
   ]);
 
   return {

--- a/src/lib/negation-game/copyViewpoint.ts
+++ b/src/lib/negation-game/copyViewpoint.ts
@@ -232,7 +232,8 @@ export const copyViewpointAndNavigate = async (
   graphToCopy: ViewpointGraph,
   title: string = "",
   description: string = "",
-  sourceId?: string
+  sourceId?: string,
+  autoPublish: boolean = false
 ): Promise<boolean> => {
   // Before storing, log the graph for debugging
   console.log("Copying graph with nodes:", graphToCopy.nodes.length);
@@ -288,14 +289,15 @@ export const copyViewpointAndNavigate = async (
       }
     }
 
-    // Navigate to the new page under the explicit space
+    // Navigate to the new page under the explicit space, optionally auto-publishing
     const space = getSpaceFromUrl();
     if (!space) {
       console.error("Space is required to navigate after copying");
       return false;
     }
-
-    const url = `/s/${space}/rationale/new`;
+    const url = `/s/${space}/rationale/new${
+      autoPublish ? "?autoPublish=true" : ""
+    }`;
     console.log("Navigating to new rationale page:", url);
 
     // Use window.location for a full page reload


### PR DESCRIPTION
…al auto-publishing

- Updated `handleCopy` in `useCopyConfirm` to accept a `publishCopy` parameter, allowing for conditional publishing.
- Enhanced `ExistingRationaleHeader` to include a switch for users to choose whether to publish after copying.
- Modified `copyViewpointAndNavigate` to handle the new `autoPublish` parameter, adjusting navigation URL accordingly.
- Implemented auto-publishing logic in `ViewpointContent` based on search parameters, improving user experience during rationale creation.