### PR TITLE
Mac-sync-board-scroll-fixes

### DIFF
--- a/src/components/experiment/multiplayer/GraphCanvas.tsx
+++ b/src/components/experiment/multiplayer/GraphCanvas.tsx
@@ -7,6 +7,7 @@ import { nodeTypes, edgeTypes } from '@/components/experiment/multiplayer/compon
 import { WebsocketProvider } from 'y-websocket';
 import { useGraphActions } from './GraphContext';
 import OffscreenNeighborPreviews from './OffscreenNeighborPreviews';
+import { useKeyboardPanning } from '@/hooks/experiment/multiplayer/useKeyboardPanning';
 
 type YProvider = WebsocketProvider | null;
 
@@ -76,6 +77,11 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({
       (graph as any)?.clearNodeSelection?.();
     } catch { }
   }, [graph]);
+
+  useKeyboardPanning({
+    connectMode,
+    onCancelConnect: graph.cancelConnect,
+  });
   React.useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const key = e.key.toLowerCase();
@@ -89,20 +95,6 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({
         return false;
       };
       if (isEditable(target) || isEditable(active)) return;
-
-      // Allow copy/paste when text is selected
-      const selection = window.getSelection();
-      if (selection && !selection.isCollapsed) {
-        return;
-      }
-
-      if (key === 'escape') {
-        if (connectMode) {
-          e.preventDefault();
-          graph.cancelConnect?.();
-        }
-        return;
-      }
 
       const isDeleteKey = key === 'delete' || key === 'backspace';
       if (isDeleteKey) {
@@ -146,9 +138,12 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({
         return;
       }
     };
+
     window.addEventListener('keydown', onKey, { capture: true });
-    return () => window.removeEventListener('keydown', onKey as any, { capture: true } as any);
-  }, [rf, graph, connectMode]);
+    return () => {
+      window.removeEventListener('keydown', onKey as any, { capture: true } as any);
+    };
+  }, [rf, graph]);
   React.useEffect(() => {
     if (!connectMode || !connectAnchorId || !onFlowMouseMove) return;
     const handler = (e: MouseEvent) => {

--- a/src/components/experiment/multiplayer/GraphCanvas.tsx
+++ b/src/components/experiment/multiplayer/GraphCanvas.tsx
@@ -323,8 +323,8 @@ export const GraphCanvas: React.FC<GraphCanvasProps> = ({
             onEdgeMouseEnter={grabMode ? undefined : onEdgeMouseEnter}
             onEdgeMouseLeave={grabMode ? undefined : onEdgeMouseLeave}
             panOnDrag={panOnDrag !== undefined ? panOnDrag : (grabMode ? [0, 1, 2] : [1])}
-            panOnScroll={panOnScroll as any}
-            zoomOnScroll={zoomOnScroll}
+            panOnScroll={panOnScroll !== undefined ? (panOnScroll as any) : true}
+            zoomOnScroll={false}
             zoomOnDoubleClick={false}
             nodesDraggable={!connectMode && !grabMode}
             nodesConnectable={!grabMode}

--- a/src/components/experiment/multiplayer/common/EdgeOverlay.tsx
+++ b/src/components/experiment/multiplayer/common/EdgeOverlay.tsx
@@ -75,29 +75,23 @@ export const EdgeOverlay: React.FC<EdgeOverlayProps> = ({
 
 
   const handleWheelCapture = React.useCallback((event: React.WheelEvent<HTMLDivElement>) => {
-    if (!(event.ctrlKey || event.metaKey)) {
-      return;
-    }
+    if (!reactFlow) return;
 
-    if (event.deltaY === 0) {
-      return;
-    }
-
-    if (!reactFlow) {
-      return;
-    }
+    // Treat two-finger trackpad scroll as pan; ignore pinch zoom
+    if (event.ctrlKey || event.metaKey) return;
 
     event.preventDefault();
     event.stopPropagation();
 
-    if (event.deltaY < 0) {
-      reactFlow.zoomIn({ duration: 0 });
-      return;
-    }
+    const viewport = reactFlow.getViewport?.();
+    if (!viewport) return;
 
-    if (event.deltaY > 0) {
-      reactFlow.zoomOut({ duration: 0 });
-    }
+    const nextViewport = {
+      x: viewport.x + event.deltaX,
+      y: viewport.y + event.deltaY,
+      zoom: viewport.zoom,
+    };
+    reactFlow.setViewport?.(nextViewport, { duration: 0 });
   }, [reactFlow]);
 
   const [isSpacePressed, setIsSpacePressed] = React.useState(false);

--- a/src/hooks/experiment/multiplayer/useKeyboardPanning.ts
+++ b/src/hooks/experiment/multiplayer/useKeyboardPanning.ts
@@ -1,0 +1,137 @@
+import { useEffect, useRef } from 'react';
+import { useReactFlow } from '@xyflow/react';
+
+interface UseKeyboardPanningOptions {
+  connectMode?: boolean;
+  onCancelConnect?: () => void;
+  enabled?: boolean;
+}
+
+/**
+ * Hook for smooth keyboard-based viewport panning using WASD/Arrow keys.
+ * Implements press-and-hold behavior with requestAnimationFrame for smooth movement.
+ */
+export function useKeyboardPanning(options: UseKeyboardPanningOptions = {}) {
+  const { connectMode, onCancelConnect, enabled = true } = options;
+  const rf = useReactFlow();
+  const heldKeysRef = useRef<{ [k: string]: boolean }>({});
+  const rafRef = useRef<number | null>(null);
+  const lastTsRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      const key = e.key.toLowerCase();
+      const target = e.target as HTMLElement | null;
+      const active = (document.activeElement as HTMLElement | null) || null;
+
+      const isEditable = (el: HTMLElement | null) => {
+        if (!el) return false;
+        const tag = el.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA') return true;
+        if (el.isContentEditable) return true;
+        return false;
+      };
+
+      if (isEditable(target) || isEditable(active)) return;
+
+      // Allow copy/paste when text is selected
+      const selection = window.getSelection();
+      if (selection && !selection.isCollapsed) {
+        return;
+      }
+
+      // Smooth WASD/Arrow key panning (press-and-hold)
+      const isPanKey = (
+        key === 'arrowleft' || key === 'arrowright' || key === 'arrowup' || key === 'arrowdown' ||
+        key === 'a' || key === 'd' || key === 'w' || key === 's'
+      );
+
+      if (isPanKey) {
+        heldKeysRef.current[key] = true;
+        e.preventDefault();
+
+        if (rafRef.current == null) {
+          lastTsRef.current = null;
+          const tick = (ts: number) => {
+            const last = lastTsRef.current;
+            lastTsRef.current = ts;
+
+            if (last != null) {
+              const dt = Math.min(50, ts - last) / 1000; // cap delta for stability
+              const viewport = rf.getViewport?.();
+
+              if (viewport) {
+                const base = 700; // px/sec
+                const left = (heldKeysRef.current['arrowleft'] || heldKeysRef.current['a']) ? 1 : 0;
+                const right = (heldKeysRef.current['arrowright'] || heldKeysRef.current['d']) ? 1 : 0;
+                const up = (heldKeysRef.current['arrowup'] || heldKeysRef.current['w']) ? 1 : 0;
+                const down = (heldKeysRef.current['arrowdown'] || heldKeysRef.current['s']) ? 1 : 0;
+                const dx = (left - right) * base * dt;
+                const dy = (up - down) * base * dt;
+
+                if (dx !== 0 || dy !== 0) {
+                  rf.setViewport?.({ x: viewport.x + dx, y: viewport.y + dy, zoom: viewport.zoom }, { duration: 0 });
+                }
+              }
+            }
+
+            // Continue if any pan keys remain held
+            const anyHeld = Object.keys(heldKeysRef.current).some(k => heldKeysRef.current[k] === true);
+            if (anyHeld) {
+              rafRef.current = requestAnimationFrame(tick);
+            } else {
+              rafRef.current = null;
+            }
+          };
+          rafRef.current = requestAnimationFrame(tick);
+        }
+        return;
+      }
+
+      // Handle escape key for connect mode
+      if (key === 'escape' && connectMode) {
+        e.preventDefault();
+        onCancelConnect?.();
+      }
+    };
+
+    const onKeyUp = (e: KeyboardEvent) => {
+      const key = e.key.toLowerCase();
+      if (heldKeysRef.current[key]) {
+        heldKeysRef.current[key] = false;
+      }
+
+      // Stop loop if nothing held
+      const anyHeld = Object.keys(heldKeysRef.current).some(k => heldKeysRef.current[k]);
+      if (!anyHeld && rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+
+    const onBlur = () => {
+      heldKeysRef.current = {};
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown, { capture: true });
+    window.addEventListener('keyup', onKeyUp, { capture: true });
+    window.addEventListener('blur', onBlur);
+
+    return () => {
+      window.removeEventListener('keydown', onKeyDown, { capture: true } as any);
+      window.removeEventListener('keyup', onKeyUp, { capture: true } as any);
+      window.removeEventListener('blur', onBlur);
+
+      // Cleanup animation frame on unmount
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    };
+  }, [enabled, connectMode, onCancelConnect, rf]);
+}


### PR DESCRIPTION
- Added useKeyboardPanning hook to enable keyboard-based panning during interactions.
- Removed redundant copy/paste handling in keydown event to streamline keyboard interactions.
- Improved cleanup of keydown event listener for better performance.