### PR TITLE
add a link for privy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ However, if you would like to attempt to run it locally, you can do so by follow
 
 The repository makes several assumptions about the environment it's running in.
 
-- It assumes that you are using postgre, privy for authentication, as well as Gemini and OpenAI for AI features.
+- It assumes that you are using postgre, [privy](https://docs.privy.io/authentication/overview) for authentication, as well as Gemini and OpenAI for AI features.
 
 ### Running the Yjs websocket server
 


### PR DESCRIPTION
When I tried to search for Privy, I ended up on a different site and even created an account before realizing it wasn’t the same app you mentioned in the README file.